### PR TITLE
Cleanup

### DIFF
--- a/src/ObjectType.ts
+++ b/src/ObjectType.ts
@@ -21,25 +21,180 @@ import {
 import GraphQLAutoRequester from '.'
 import { lazyProperty } from './utils'
 
-export default class AutoGraphQLObjectType {
+export type GraphQLAutoRequesterMeta = {
   execute: (selectionSet: SelectionSetNode) => Promise<any>
   type: GraphQLObjectType
   parent: GraphQLAutoRequester
-  __typename: string
+}
+// TODO: This should be downgradeable to all possible input types.
+// The issue is that there's no way to tell all the possible input types from the GraphQLSchema type or any subtypes.
+export type FieldArguments = {
+  [index: string]: any
+}
+// TODO: This should be downgradeable to all possible scalar output types, null and AutoGraphQLObjectType.
+// The issue is that there's no way to tell all the possible scalar output types from the GraphQLSchema type or any subtypes.
+export type ElementReturnType = any
+
+export const graphQLAutoRequesterMeta = Symbol('graphql-auto-requester-meta')
+
+const configureProperty = (instance: AutoGraphQLObjectType, propertyName: string, fieldName: string, field: GraphQLField<any, any>, args?: ArgumentNode[]) => {
+  const type = field.type
+  let baseType = type
+  if (isNonNullType(type)) {
+    baseType = type.ofType
+  }
+  if (isAbstractType(baseType)) {
+    configureAbstractProperty(instance, propertyName, fieldName, args)
+  } else if (isLeafType(baseType)) {
+    lazyProperty(instance, propertyName, () => resolveField(instance, propertyName, fieldName, undefined, args))
+  } else if (isListType(baseType)) {
+    configureListProperty(instance, propertyName, fieldName, baseType, args)
+  } else if (isObjectType(baseType)) {
+    const _baseType: GraphQLObjectType = baseType
+    if (isNonNullType(type)) {
+      lazyProperty(instance, propertyName, () => new AutoGraphQLObjectType(
+        instance[graphQLAutoRequesterMeta].parent,
+        (selectionSet) => resolveField(instance, propertyName, fieldName, selectionSet, args),
+        _baseType,
+      ))
+    } else {
+      lazyProperty(instance, propertyName, async () => {
+        const subField = new AutoGraphQLObjectType(
+          instance[graphQLAutoRequesterMeta].parent,
+          (selectionSet) => resolveField(instance, propertyName, fieldName, selectionSet, args),
+          _baseType,
+        )
+        const exists = await resolveField(subField, '__typename', '__typename')
+        if (!exists) {
+          return exists
+        }
+        return subField
+      })
+    }
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _exhaustiveCheck: never = baseType
+    throw new Error('unreachable code branch')
+  }
+}
+
+const configureAbstractProperty = (instance: AutoGraphQLObjectType, propertyName: string, fieldName: string, args?: ArgumentNode[]) => {
+  lazyProperty(instance, propertyName, async () => {
+    const { __typename: typeName } = await resolveField(instance, propertyName, fieldName, {
+      kind: Kind.SELECTION_SET,
+      selections: [{
+        kind: Kind.FIELD,
+        name: {
+          kind: Kind.NAME,
+          value: '__typename',
+        },
+      }],
+    }, args)
+    if (!typeName) {
+      return typeName
+    }
+
+    const concreteType = instance[graphQLAutoRequesterMeta].parent.schema.getTypeMap()[typeName] as GraphQLObjectType
+    return new AutoGraphQLObjectType(instance[graphQLAutoRequesterMeta].parent, (selectionSet) => resolveField(instance, propertyName, fieldName, {
+      kind: Kind.SELECTION_SET,
+      selections: [{
+        kind: Kind.INLINE_FRAGMENT,
+        typeCondition: {
+          kind: Kind.NAMED_TYPE,
+          name: {
+            kind: Kind.NAME,
+            value: typeName,
+          },
+        },
+        selectionSet,
+      }],
+    }, args), concreteType)
+  })
+}
+
+const configureListProperty = (instance: AutoGraphQLObjectType, propertyName: string, fieldName: string, type: GraphQLList<any>, args?: ArgumentNode[]) => {
+  const namedType = getNamedType(type)
+  if (isLeafType(namedType)) {
+    lazyProperty(instance, propertyName, () => resolveField(instance, propertyName, fieldName, undefined, args))
+    return
+  }
+  lazyProperty(instance, propertyName, async () => {
+    const list = await resolveField(instance, propertyName, fieldName, {
+      kind: Kind.SELECTION_SET,
+      selections: [{
+        kind: Kind.FIELD,
+        name: {
+          kind: Kind.NAME,
+          value: '__typename',
+        },
+      }],
+    }, args)
+
+    return list && list.map((element: any, index: number) => {
+      if (!element) {
+        return element
+      }
+      const concreteType = instance[graphQLAutoRequesterMeta].parent.schema.getTypeMap()[element.__typename] as GraphQLObjectType
+      return new AutoGraphQLObjectType(instance[graphQLAutoRequesterMeta].parent, async (selectionSet) => {
+        const result = await resolveField(instance, propertyName, fieldName, {
+          kind: Kind.SELECTION_SET,
+          selections: [{
+            kind: Kind.INLINE_FRAGMENT,
+            typeCondition: {
+              kind: Kind.NAMED_TYPE,
+              name: {
+                kind: Kind.NAME,
+                value: element.__typename,
+              },
+            },
+            selectionSet,
+          }],
+        }, args)
+        return result[index]
+      }, concreteType)
+    })
+  })
+}
+
+const resolveField = async (instance: AutoGraphQLObjectType, propertyName: string, fieldName: string, selectionSet?: SelectionSetNode, args?: ArgumentNode[]) => {
+  const result = await instance[graphQLAutoRequesterMeta].execute({
+    kind: Kind.SELECTION_SET,
+    selections: [{
+      alias: propertyName !== fieldName ? {
+        kind: Kind.NAME,
+        value: propertyName,
+      } : undefined,
+      arguments: args,
+      kind: Kind.FIELD,
+      name: {
+        kind: Kind.NAME,
+        value: fieldName,
+      },
+      selectionSet,
+    }],
+  })
+
+  return result[propertyName]
+}
+
+export default class AutoGraphQLObjectType {
+  [graphQLAutoRequesterMeta]: GraphQLAutoRequesterMeta
+  [index: string]: ElementReturnType | Promise<ElementReturnType> | ((args: any) => Promise<ElementReturnType>)
 
   constructor (
     parent: GraphQLAutoRequester,
     execute: (selectionSet: SelectionSetNode) => Promise<any>,
     type: GraphQLObjectType,
   ) {
-    this.execute = execute
-    this.type = type
-    this.parent = parent
+    this[graphQLAutoRequesterMeta] = {
+      execute,
+      type,
+      parent,
+    }
     this.__typename = type.name
 
-    for (const [fieldName, field] of Object.entries(this.type.getFields())) {
+    for (const [fieldName, field] of Object.entries(type.getFields())) {
       if (field.args.length) {
-        // @ts-ignore
         this[fieldName] = (args: any = {}) => {
           const inputs: ArgumentNode[] = []
           for (const argument of field.args) {
@@ -58,154 +213,13 @@ export default class AutoGraphQLObjectType {
           }
           const key = `${fieldName}_${digest(args)}`
           if (!Object.prototype.hasOwnProperty.call(this, key)) {
-            this._configureProperty(key, fieldName, field, inputs)
+            configureProperty(this, key, fieldName, field, inputs)
           }
-          // @ts-ignore
-          return this[key]
+          return this[key] as Promise<ElementReturnType>
         }
       } else {
-        this._configureProperty(fieldName, fieldName, field)
+        configureProperty(this, fieldName, fieldName, field)
       }
     }
-  }
-
-  _configureProperty (propertyName: string, fieldName: string, field: GraphQLField<any, any>, args?: ArgumentNode[]) {
-    const type = field.type
-    let baseType = type
-    if (isNonNullType(type)) {
-      baseType = type.ofType
-    }
-    if (isAbstractType(baseType)) {
-      this._configureAbstractProperty(propertyName, fieldName, args)
-    } else if (isLeafType(baseType)) {
-      lazyProperty(this, propertyName, () => this.resolveField(propertyName, fieldName, undefined, args))
-    } else if (isListType(baseType)) {
-      this._configureListProperty(propertyName, fieldName, baseType, args)
-    } else if (isObjectType(baseType)) {
-      const _baseType: GraphQLObjectType = baseType
-      if (isNonNullType(type)) {
-        lazyProperty(this, propertyName, () => new AutoGraphQLObjectType(
-          this.parent,
-          (selectionSet) => this.resolveField(propertyName, fieldName, selectionSet, args),
-          _baseType,
-        ))
-      } else {
-        lazyProperty(this, propertyName, async () => {
-          const subField = new AutoGraphQLObjectType(
-            this.parent,
-            (selectionSet) => this.resolveField(propertyName, fieldName, selectionSet, args),
-            _baseType,
-          )
-          const exists = await subField.resolveField('__typename', '__typename')
-          if (!exists) {
-            return exists
-          }
-          return subField
-        })
-      }
-    } else {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const _exhaustiveCheck: never = baseType
-      throw new Error('unreachable code branch')
-    }
-  }
-
-  _configureAbstractProperty (propertyName: string, fieldName: string, args?: ArgumentNode[]) {
-    lazyProperty(this, propertyName, async () => {
-      const { __typename: typeName } = await this.resolveField(propertyName, fieldName, {
-        kind: Kind.SELECTION_SET,
-        selections: [{
-          kind: Kind.FIELD,
-          name: {
-            kind: Kind.NAME,
-            value: '__typename',
-          },
-        }],
-      }, args)
-      if (!typeName) {
-        return typeName
-      }
-
-      const concreteType = this.parent.schema.getTypeMap()[typeName] as GraphQLObjectType
-      return new AutoGraphQLObjectType(this.parent, (selectionSet) => this.resolveField(propertyName, fieldName, {
-        kind: Kind.SELECTION_SET,
-        selections: [{
-          kind: Kind.INLINE_FRAGMENT,
-          typeCondition: {
-            kind: Kind.NAMED_TYPE,
-            name: {
-              kind: Kind.NAME,
-              value: typeName,
-            },
-          },
-          selectionSet,
-        }],
-      }, args), concreteType)
-    })
-  }
-
-  _configureListProperty (propertyName: string, fieldName: string, type: GraphQLList<any>, args?: ArgumentNode[]) {
-    const namedType = getNamedType(type)
-    if (isLeafType(namedType)) {
-      lazyProperty(this, propertyName, () => this.resolveField(propertyName, fieldName, undefined, args))
-      return
-    }
-    lazyProperty(this, propertyName, async () => {
-      const list = await this.resolveField(propertyName, fieldName, {
-        kind: Kind.SELECTION_SET,
-        selections: [{
-          kind: Kind.FIELD,
-          name: {
-            kind: Kind.NAME,
-            value: '__typename',
-          },
-        }],
-      }, args)
-
-      return list && list.map((element: any, index: number) => {
-        if (!element) {
-          return element
-        }
-        const concreteType = this.parent.schema.getTypeMap()[element.__typename] as GraphQLObjectType
-        return new AutoGraphQLObjectType(this.parent, async (selectionSet) => {
-          const result = await this.resolveField(propertyName, fieldName, {
-            kind: Kind.SELECTION_SET,
-            selections: [{
-              kind: Kind.INLINE_FRAGMENT,
-              typeCondition: {
-                kind: Kind.NAMED_TYPE,
-                name: {
-                  kind: Kind.NAME,
-                  value: element.__typename,
-                },
-              },
-              selectionSet,
-            }],
-          }, args)
-          return result[index]
-        }, concreteType)
-      })
-    })
-  }
-
-  async resolveField (propertyName: string, fieldName: string, selectionSet?: SelectionSetNode, args?: ArgumentNode[]) {
-    const result = await this.execute({
-      kind: Kind.SELECTION_SET,
-      selections: [{
-        alias: propertyName !== fieldName ? {
-          kind: Kind.NAME,
-          value: propertyName,
-        } : undefined,
-        arguments: args,
-        kind: Kind.FIELD,
-        name: {
-          kind: Kind.NAME,
-          value: fieldName,
-        },
-        selectionSet,
-      }],
-    })
-
-    return result[propertyName]
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import { GraphQLSchema, execute, DocumentNode, Kind, SelectionSetNode, Operation
 import { createResultProxy } from 'graphql-result-proxy'
 
 import AutoGraphQLObjectType from './ObjectType'
-import { lazyProperty } from './utils'
 
 export default class GraphQLAutoRequester {
   schema: GraphQLSchema
@@ -19,13 +18,10 @@ export default class GraphQLAutoRequester {
     this.schema = schema
     this._executionCount = 0
 
-    lazyProperty(this, 'query', () => {
-      const query = this.schema.getQueryType()
-      if (!query) {
-        return query
-      }
-      return new AutoGraphQLObjectType(this, (selectionSet) => this.handleQuerySelectionSet(selectionSet), query)
-    })
+    const query = this.schema.getQueryType()
+    if (query) {
+      this.query = new AutoGraphQLObjectType(this, (selectionSet) => this.handleQuerySelectionSet(selectionSet), query)
+    }
   }
 
   async execute (document: DocumentNode) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,9 @@ export default class GraphQLAutoRequester {
     this.schema = schema
     this._executionCount = 0
 
-    const query = this.schema.getQueryType()
-    if (query) {
-      this.query = new AutoGraphQLObjectType(this, (selectionSet) => this.handleQuerySelectionSet(selectionSet), query)
+    const queryType = this.schema.getQueryType()
+    if (queryType) {
+      this.query = new AutoGraphQLObjectType(this, (selectionSet) => this.handleQuerySelectionSet(selectionSet), queryType)
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,22 @@
-export const lazyProperty = <T>(object: any, property: string | number, creator: () => T) => {
+// Gets the union type of all keys of T
+type ValueOf<T> = T[keyof T]
+
+export const lazyProperty = <
+  Result,
+  // Checks the index of Target extends Result | ValueOf<Target>, i.e. that Result is valid to be added to the object based on index type
+  Target extends { [index: string]: Result | ValueOf<Target> }
+>(
+    target: Target,
+    property: string,
+    instantiator: () => Result,
+  ) => {
   let init = false
-  let data: T
-  Object.defineProperty(object, property, {
+  let data: Result
+  Object.defineProperty(target, property, {
     get: () => {
       if (!init) {
         init = true
-        data = creator()
+        data = instantiator()
       }
       return data
     },


### PR DESCRIPTION
 - Removes some ts-ignores and tightens typescript restrictions generally
 - Should now support all GraphQL schemas, even if they have weird field names like `_configureAbstractProperty` or `resolveField`