### PR TITLE
Add a global result cache.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2528,6 +2528,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An automatic graphql request builder based on used fields",
   "main": "lib/index.js",
   "dependencies": {
+    "deepmerge": "^4.2.2",
     "graphql-result-proxy": "^0.1.2",
     "json-hash": "^1.2.0"
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,14 +1,26 @@
-import { GraphQLSchema, execute, DocumentNode, Kind, SelectionNode, OperationDefinitionNode } from 'graphql'
+import { GraphQLSchema, execute, DocumentNode, Kind, SelectionNode, SelectionSetNode } from 'graphql'
 // @ts-ignore There are no typings for this module
 import { createResultProxy } from 'graphql-result-proxy'
 import AutoGraphQLObjectType from './ObjectType'
+import {
+  mergeSelectionSetInToSelectionSet,
+  leftOuterJoinSelectionSets,
+} from './selectionSet'
+import { dataMerge } from './utils'
 
 import GraphQLAutoRequester from '.'
 jest.mock('graphql')
 jest.mock('graphql-result-proxy')
 jest.mock('./ObjectType')
+jest.mock('./selectionSet')
+jest.mock('./utils')
 
 describe('GraphQLAutoRequester', () => {
+  afterEach(() => {
+    ;(leftOuterJoinSelectionSets as jest.Mock).mockReset()
+    ;(mergeSelectionSetInToSelectionSet as jest.Mock).mockReset()
+  })
+
   it('constructs without a Query Type', () => {
     const schema: GraphQLSchema = {
       getQueryType: () => null,
@@ -37,17 +49,45 @@ describe('GraphQLAutoRequester', () => {
     const requester = new GraphQLAutoRequester(schema)
 
     describe('execute', () => {
+      beforeEach(() => {
+        requester._fetchedSelectionSet = {
+          kind: Kind.SELECTION_SET,
+          selections: [],
+        }
+      })
+
       it('forwards to graphql-js execute, and creates a result proxy', async () => {
         const intermediate = Symbol('inter')
         ;(execute as jest.Mock).mockResolvedValue(intermediate)
+        const dataMergeResult = Symbol('dataMergeResult')
+        ;(dataMerge as jest.Mock).mockReturnValue(dataMergeResult)
         const result = Symbol('result')
-        ;(createResultProxy as jest.Mock).mockResolvedValue(result)
+        ;(createResultProxy as jest.Mock).mockReturnValue(result)
 
-        const document: DocumentNode = Symbol('documentNode') as any as DocumentNode
+        const selectionSet = Symbol('SelectionSet')
+        const document: DocumentNode = {
+          kind: Kind.DOCUMENT,
+          definitions: [{
+            kind: Kind.OPERATION_DEFINITION,
+            operation: 'query',
+            selectionSet: (selectionSet as any) as SelectionSetNode,
+          }],
+        }
         await expect(requester.execute(document)).resolves.toBe(result)
 
-        expect(createResultProxy).toHaveBeenCalledTimes(1)
-        expect(createResultProxy).toHaveBeenCalledWith(intermediate)
+        expect(mergeSelectionSetInToSelectionSet).toHaveBeenCalledTimes(1)
+        expect(mergeSelectionSetInToSelectionSet).toHaveBeenCalledWith(
+          requester._fetchedSelectionSet,
+          selectionSet
+        )
+
+        expect(dataMerge).toHaveBeenCalledTimes(1)
+        expect(requester._fetchedData).toBe(dataMergeResult)
+
+        expect(createResultProxy).toHaveBeenCalledTimes(2)
+        expect(createResultProxy).toHaveBeenNthCalledWith(1, intermediate)
+        expect(createResultProxy).toHaveBeenNthCalledWith(2, { data: dataMergeResult })
+        expect(requester._fetchedResultProxy).toBe(result)
 
         expect(execute).toHaveBeenCalledTimes(1)
         expect(execute).toHaveBeenCalledWith({
@@ -80,7 +120,13 @@ describe('GraphQLAutoRequester', () => {
     })
 
     describe('handleQuerySelectionSet', () => {
+      let fetchedResultProxyMock
+      let fetchedSelectionSetMock
       beforeEach(() => {
+        fetchedResultProxyMock = Symbol('_fetchedResultProxyMock')
+        requester._fetchedResultProxy = fetchedResultProxyMock
+        fetchedSelectionSetMock = Symbol('_fetchedSelectionSetMock')
+        requester._fetchedSelectionSet = fetchedSelectionSetMock
         jest.spyOn(requester, 'createNextRequest')
       })
 
@@ -88,8 +134,31 @@ describe('GraphQLAutoRequester', () => {
         ;(requester.createNextRequest as jest.Mock).mockReset()
       })
 
+      it('immediately returns the current results if the data has been fetched', () => {
+        ;(leftOuterJoinSelectionSets as jest.Mock).mockReturnValue({
+          kind: Kind.SELECTION_SET,
+          selections: [],
+        })
+
+        const selection = Symbol('selection')
+        const selectionSet = {
+          kind: Kind.SELECTION_SET,
+          selections: [
+            selection as any as SelectionNode,
+          ],
+        }
+        expect(requester.handleQuerySelectionSet(selectionSet)).toBe(fetchedResultProxyMock)
+
+        expect(leftOuterJoinSelectionSets).toHaveBeenCalledTimes(1)
+        expect(leftOuterJoinSelectionSets).toHaveBeenCalledWith(selectionSet, fetchedSelectionSetMock)
+      })
+
       it('creates the next request if required', async () => {
         const result = Symbol('result')
+        const nextRequestSelectionSet = {
+          kind: Kind.SELECTION_SET,
+          selections: [],
+        }
         ;(requester.createNextRequest as jest.Mock).mockImplementationOnce(() => {
           requester._nextRequestPromise = result as any
           requester._nextRequest = {
@@ -98,54 +167,60 @@ describe('GraphQLAutoRequester', () => {
               {
                 kind: Kind.OPERATION_DEFINITION,
                 operation: 'query',
-                selectionSet: {
-                  kind: Kind.SELECTION_SET,
-                  selections: [],
-                },
+                selectionSet: nextRequestSelectionSet,
               },
             ],
           }
         })
 
         const selection = Symbol('selection')
-        expect(requester.handleQuerySelectionSet({
+        const selectionSet = {
           kind: Kind.SELECTION_SET,
           selections: [
             selection as any as SelectionNode,
           ],
-        })).toBe(result)
-        expect((requester._nextRequest!.definitions[0] as OperationDefinitionNode).selectionSet.selections).toEqual([
-          selection,
-        ])
+        }
+        ;(leftOuterJoinSelectionSets as jest.Mock).mockReturnValue(selectionSet)
+
+        expect(requester.handleQuerySelectionSet(selectionSet)).toBe(result)
+        expect(mergeSelectionSetInToSelectionSet).toHaveBeenCalledWith(
+          nextRequestSelectionSet,
+          selectionSet
+        )
       })
 
       it('attaches to the next request if available', async () => {
         const result = Symbol('result')
         requester._nextRequestPromise = result as any
+        const nextRequestSelectionSet = {
+          kind: Kind.SELECTION_SET,
+          selections: [],
+        }
         requester._nextRequest = {
           kind: Kind.DOCUMENT,
           definitions: [
             {
               kind: Kind.OPERATION_DEFINITION,
               operation: 'query',
-              selectionSet: {
-                kind: Kind.SELECTION_SET,
-                selections: [],
-              },
+              selectionSet: nextRequestSelectionSet,
             },
           ],
         }
 
         const selection = Symbol('selection')
-        expect(requester.handleQuerySelectionSet({
+        const selectionSet = {
           kind: Kind.SELECTION_SET,
           selections: [
             selection as any as SelectionNode,
           ],
-        })).toBe(result)
-        expect((requester._nextRequest!.definitions[0] as OperationDefinitionNode).selectionSet.selections).toEqual([
-          selection,
-        ])
+        }
+        ;(leftOuterJoinSelectionSets as jest.Mock).mockReturnValue(selectionSet)
+
+        expect(requester.handleQuerySelectionSet(selectionSet)).toBe(result)
+        expect(mergeSelectionSetInToSelectionSet).toHaveBeenCalledWith(
+          nextRequestSelectionSet,
+          selectionSet
+        )
       })
     })
   })

--- a/src/selectionSet.test.ts
+++ b/src/selectionSet.test.ts
@@ -1,0 +1,337 @@
+import { Kind, parse, FragmentDefinitionNode, NameNode, BooleanValueNode, IntValueNode, NullValueNode, VariableNode, ObjectValueNode, ObjectFieldNode, ValueNode, ListValueNode } from 'graphql'
+
+import {
+  mergeSelectionSetInToSelectionSet,
+  leftOuterJoinSelectionSets,
+  areSimilarFieldLists,
+  isSimilarValueNode,
+} from './selectionSet'
+
+const getNameNode = (name: string): NameNode => ({
+  kind: Kind.NAME,
+  value: name,
+})
+const getBooleanValue = (value: boolean): BooleanValueNode => ({
+  kind: Kind.BOOLEAN,
+  value,
+})
+const getIntValue = (value: string): IntValueNode => ({
+  kind: Kind.INT,
+  value,
+})
+const getNullValue = (): NullValueNode => ({
+  kind: Kind.NULL,
+})
+const getVariableNode = (name: string): VariableNode => ({
+  kind: Kind.VARIABLE,
+  name: getNameNode(name),
+})
+const getObjectFieldNode = (name: string, value: ValueNode): ObjectFieldNode => ({
+  kind: Kind.OBJECT_FIELD,
+  name: getNameNode(name),
+  value,
+})
+const getObjectNode = (fields: ObjectFieldNode[]): ObjectValueNode => ({
+  kind: Kind.OBJECT,
+  fields,
+})
+const getListNode = (values: ValueNode[]): ListValueNode => ({
+  kind: Kind.LIST,
+  values,
+})
+
+describe('isSimilarValueNode', () => {
+  it('works for nulls', () => {
+    expect(isSimilarValueNode(getNullValue(), getNullValue())).toBe(true)
+  })
+
+  it('works for boolean values', () => {
+    expect(isSimilarValueNode(getBooleanValue(true), getBooleanValue(true))).toBe(true)
+    expect(isSimilarValueNode(getBooleanValue(false), getBooleanValue(false))).toBe(true)
+
+    expect(isSimilarValueNode(getBooleanValue(true), getBooleanValue(false))).toBe(false)
+    expect(isSimilarValueNode(getBooleanValue(false), getBooleanValue(true))).toBe(false)
+  })
+
+  it('works for variables', () => {
+    expect(isSimilarValueNode(getVariableNode('name'), getVariableNode('name'))).toBe(true)
+    expect(isSimilarValueNode(getVariableNode('name'), getVariableNode('name2'))).toBe(false)
+  })
+
+  describe('for objects', () => {
+    it('works without any fields', () => {
+      expect(isSimilarValueNode(getObjectNode([]), getObjectNode([]))).toBe(true)
+    })
+
+    it('works with a matching field', () => {
+      expect(isSimilarValueNode(
+        getObjectNode([
+          getObjectFieldNode('test', getNullValue()),
+        ]),
+        getObjectNode([
+          getObjectFieldNode('test', getNullValue()),
+        ]),
+      )).toBe(true)
+    })
+
+    it('fails with a field that differs in name', () => {
+      expect(isSimilarValueNode(
+        getObjectNode([
+          getObjectFieldNode('test', getNullValue()),
+        ]),
+        getObjectNode([
+          getObjectFieldNode('test2', getNullValue()),
+        ]),
+      )).toBe(false)
+    })
+
+    it('fails with a field that differs in value', () => {
+      expect(isSimilarValueNode(
+        getObjectNode([
+          getObjectFieldNode('test', getNullValue()),
+        ]),
+        getObjectNode([
+          getObjectFieldNode('test', getBooleanValue(false)),
+        ]),
+      )).toBe(false)
+    })
+  })
+
+  describe('for lists', () => {
+    it('works without any entries', () => {
+      expect(isSimilarValueNode(getListNode([]), getListNode([]))).toBe(true)
+    })
+
+    it('fails with mismatching entry counts', () => {
+      expect(isSimilarValueNode(getListNode([getNullValue()]), getListNode([]))).toBe(false)
+    })
+
+    it('fails with mismatching entry', () => {
+      expect(isSimilarValueNode(getListNode([getNullValue()]), getListNode([getBooleanValue(true)]))).toBe(false)
+    })
+  })
+})
+
+describe('areSimilarFieldLists', () => {
+  it('fails for different lengths', () => {
+    expect(areSimilarFieldLists([{
+      name: getNameNode('a'),
+      value: getBooleanValue(false),
+    }], [])).toBe(false)
+  })
+
+  it('fails for differently named args', () => {
+    expect(areSimilarFieldLists(
+      [{
+        name: getNameNode('a'),
+        value: getBooleanValue(false),
+      }],
+      [{
+        name: getNameNode('b'),
+        value: getBooleanValue(false),
+      }]
+    )).toBe(false)
+  })
+
+  it('fails for differently kind args', () => {
+    expect(areSimilarFieldLists(
+      [{
+        name: getNameNode('a'),
+        value: getBooleanValue(false),
+      }],
+      [{
+        name: getNameNode('a'),
+        value: getIntValue(10),
+      }]
+    )).toBe(false)
+  })
+
+  it('fails for different variable args', () => {
+    expect(areSimilarFieldLists(
+      [{
+        name: getNameNode('a'),
+        value: getVariableNode('test'),
+      }],
+      [{
+        name: getNameNode('a'),
+        value: getVariableNode('notTest'),
+      }]
+    )).toBe(false)
+  })
+
+  // Success scenarios
+  it('works for blank arrays', () => {
+    expect(areSimilarFieldLists([], [])).toBe(true)
+  })
+
+  it('works for single argument', () => {
+    expect(areSimilarFieldLists(
+      [{
+        name: getNameNode('a'),
+        value: getBooleanValue(false),
+      }],
+      [{
+        name: getNameNode('a'),
+        value: getBooleanValue(false),
+      }]
+    )).toBe(true)
+  })
+
+  it('works for null argument', () => {
+    expect(areSimilarFieldLists(
+      [{
+        name: getNameNode('a'),
+        value: getNullValue(),
+      }],
+      [{
+        name: getNameNode('a'),
+        value: getNullValue(),
+      }]
+    )).toBe(true)
+  })
+
+  it('works for variable argument', () => {
+    expect(areSimilarFieldLists(
+      [{
+        name: getNameNode('a'),
+        value: getVariableNode('variableName'),
+      }],
+      [{
+        name: getNameNode('a'),
+        value: getVariableNode('variableName'),
+      }]
+    )).toBe(true)
+  })
+
+  it('works for multiples arguments in order', () => {
+    expect(areSimilarFieldLists(
+      [{
+        name: getNameNode('a'),
+        value: getBooleanValue(false),
+      }, {
+        name: getNameNode('b'),
+        value: getBooleanValue(false),
+      }],
+      [{
+        name: getNameNode('a'),
+        value: getBooleanValue(false),
+      }, {
+        name: getNameNode('b'),
+        value: getBooleanValue(false),
+      }]
+    )).toBe(true)
+  })
+
+  it('works for multiples arguments out of order', () => {
+    expect(areSimilarFieldLists(
+      [{
+        name: getNameNode('a'),
+        value: getBooleanValue(false),
+      }, {
+        name: getNameNode('b'),
+        value: getBooleanValue(false),
+      }],
+      [{
+        name: getNameNode('b'),
+        value: getBooleanValue(false),
+      }, {
+        name: getNameNode('a'),
+        value: getBooleanValue(false),
+      }]
+    )).toBe(true)
+  })
+})
+
+describe('mergeSelectionSetInToSelectionSet', () => {
+  const data = `
+    fragment inputA on Test {
+      test1
+      test2 {
+        __typename
+        ... on Test2 {
+          fieldA
+        }
+      }
+    }
+
+    fragment inputB on Test {
+      test2 {
+        ... on Test2 {
+          fieldB
+        }
+      }
+    }
+
+    fragment output on Test {
+      test1
+      test2 {
+        __typename
+        ... on Test2 {
+          fieldA
+          fieldB
+        }
+      }
+    }
+  `
+  it('merges sets correctly', () => {
+    const document = parse(data, { noLocation: true })
+    const inputA = (document.definitions.find(def => def.kind === Kind.FRAGMENT_DEFINITION && def.name.value === 'inputA') as FragmentDefinitionNode).selectionSet
+    const inputB = (document.definitions.find(def => def.kind === Kind.FRAGMENT_DEFINITION && def.name.value === 'inputB') as FragmentDefinitionNode).selectionSet
+    const output = (document.definitions.find(def => def.kind === Kind.FRAGMENT_DEFINITION && def.name.value === 'output') as FragmentDefinitionNode).selectionSet
+
+    mergeSelectionSetInToSelectionSet(inputA, inputB)
+    expect(inputA).toEqual(output)
+  })
+})
+
+describe('leftOuterJoinSelectionSets', () => {
+  const data = `
+    fragment inputA on Test {
+      test1
+      test2 {
+        ... on Test2 {
+          fieldA(argA: true)
+          fieldB
+          aliasedField
+          alias2: aliasedField2
+          defaultArgField
+          defaultArgField2(withArg: true)
+        }
+      }
+    }
+
+    fragment inputB on Test {
+      test1
+      test2 {
+        ... on Test2 {
+          fieldA(argA: false)
+          alias: aliasedField
+          aliasedField2
+          defaultArgField(withArg: true)
+          defaultArgField2
+        }
+      }
+    }
+
+    fragment output on Test {
+      test2 {
+        ... on Test2 {
+          fieldA(argA: true)
+          fieldB
+          aliasedField
+          alias2: aliasedField2
+          defaultArgField
+          defaultArgField2(withArg: true)
+        }
+      }
+    }
+  `
+  it('merges sets correctly', () => {
+    const document = parse(data, { noLocation: true })
+    const inputA = (document.definitions.find(def => def.kind === Kind.FRAGMENT_DEFINITION && def.name.value === 'inputA') as FragmentDefinitionNode).selectionSet
+    const inputB = (document.definitions.find(def => def.kind === Kind.FRAGMENT_DEFINITION && def.name.value === 'inputB') as FragmentDefinitionNode).selectionSet
+    const output = (document.definitions.find(def => def.kind === Kind.FRAGMENT_DEFINITION && def.name.value === 'output') as FragmentDefinitionNode).selectionSet
+
+    expect(leftOuterJoinSelectionSets(inputA, inputB)).toEqual(output)
+  })
+})

--- a/src/selectionSet.ts
+++ b/src/selectionSet.ts
@@ -1,0 +1,177 @@
+import { SelectionSetNode, SelectionNode, FieldNode, Kind, VariableNode, InlineFragmentNode, ValueNode, NameNode } from 'graphql'
+
+export const isSimilarValueNode = (left: ValueNode, right: ValueNode): boolean => {
+  if (left.kind !== right.kind) {
+    return false
+  }
+  if (left.kind === Kind.NULL) {
+    return true
+  }
+  if (left.kind === Kind.VARIABLE) {
+    return left.name.value === (right as VariableNode).name.value
+  }
+  if (left.kind === Kind.OBJECT) {
+    return areSimilarFieldLists(left.fields, (right as any).fields)
+  }
+  if (left.kind === Kind.LIST) {
+    if (left.values.length !== (right as any).values.length) {
+      return false
+    }
+    for (let i = 0; i < left.values.length; i++) {
+      if (!isSimilarValueNode(left.values[i], (right as any).values[i])) {
+        return false
+      }
+    }
+    return true
+  }
+
+  if (left.value === (right as any).value) {
+    return true
+  }
+
+  return false
+}
+
+type FieldStructure = {name: NameNode, value: ValueNode}
+export const areSimilarFieldLists = (left: readonly FieldStructure[], right: readonly FieldStructure[]): boolean => {
+  if (left.length !== right.length) {
+    return false
+  }
+
+  const leftByName: {[index: string]: FieldStructure} = {}
+  for (const argument of left) {
+    leftByName[argument.name.value] = argument
+  }
+  for (const rightArg of right) {
+    const leftArg = leftByName[rightArg.name.value]
+    if (!leftArg) {
+      return false
+    }
+
+    if (isSimilarValueNode(leftArg.value, rightArg.value)) {
+      continue
+    }
+
+    return false
+  }
+
+  return true
+}
+
+export const isSimilarFieldNode = (left: FieldNode, right: FieldNode): boolean => {
+  if ((left.alias && left.alias.value) !== (right.alias && right.alias.value)) {
+    return false
+  }
+
+  if (left.name.value !== right.name.value) {
+    return false
+  }
+
+  if ((left.arguments && !right.arguments) || (!left.arguments && right.arguments)) {
+    return false
+  }
+
+  if (left.arguments && right.arguments) {
+    if (!areSimilarFieldLists(left.arguments, right.arguments)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+const isSimilarSelectionNode = (left: SelectionNode, right: SelectionNode) => {
+  if (left.kind !== right.kind) {
+    return false
+  }
+  if (left.kind === Kind.FIELD) {
+    return isSimilarFieldNode(left, right as FieldNode)
+  }
+  if (left.kind === Kind.INLINE_FRAGMENT) {
+    return left.typeCondition?.name.value === (right as InlineFragmentNode).typeCondition?.name.value
+  }
+  if (left.kind === Kind.FRAGMENT_SPREAD) {
+    throw new Error('Fragment spreads are unsupported')
+  }
+
+  return false
+}
+
+export const mergeFieldNodeInToSelectionSet = (selectionSet: SelectionSetNode, selection: SelectionNode) => {
+  if (selection.kind === Kind.FRAGMENT_SPREAD) {
+    throw new Error('Fragment spreads are unsupported')
+  }
+  let existingSelection: FieldNode | InlineFragmentNode = selectionSet.selections.find(s => isSimilarSelectionNode(s, selection)) as FieldNode | InlineFragmentNode
+  if (!existingSelection) {
+    if (selection.kind === Kind.FIELD) {
+      existingSelection = {
+        ...selection,
+        selectionSet: selection.selectionSet && {
+          kind: Kind.SELECTION_SET,
+          selections: [],
+        },
+      }
+    }
+    if (selection.kind === Kind.INLINE_FRAGMENT) {
+      existingSelection = {
+        ...selection,
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: [],
+        },
+      }
+    }
+    ;(selectionSet.selections as any as SelectionNode[]).push(existingSelection)
+  }
+  if (existingSelection.selectionSet && selection.selectionSet) {
+    mergeSelectionSetInToSelectionSet(existingSelection.selectionSet, selection.selectionSet)
+  }
+}
+
+export const mergeSelectionSetInToSelectionSet = (existingSelection: SelectionSetNode, selectionSet: SelectionSetNode) => {
+  for (const subSelection of selectionSet.selections) {
+    mergeFieldNodeInToSelectionSet(existingSelection, subSelection)
+  }
+}
+
+// NOTE: We can assume that the RIGHT selection set is built without duplicate keys.
+export const leftOuterJoinSelectionSets = (leftSelectionSet: SelectionSetNode, rightSelectionSet: SelectionSetNode): SelectionSetNode => {
+  const result: SelectionSetNode = {
+    kind: Kind.SELECTION_SET,
+    selections: [],
+  }
+
+  for (const leftSelection of leftSelectionSet.selections) {
+    if (leftSelection.kind === Kind.FRAGMENT_SPREAD) {
+      throw new Error('Fragment spreads are unsupported')
+    }
+
+    let found = false
+    for (const rightSelection of rightSelectionSet.selections) {
+      if (rightSelection.kind === Kind.FRAGMENT_SPREAD) {
+        throw new Error('Fragment spreads are unsupported')
+      }
+
+      if (isSimilarSelectionNode(leftSelection, rightSelection)) {
+        if (leftSelection.selectionSet && rightSelection.selectionSet) {
+          const leftOuterJoinSub = leftOuterJoinSelectionSets(leftSelection.selectionSet, rightSelection.selectionSet)
+          if (leftOuterJoinSub.selections.length !== 0) {
+            mergeFieldNodeInToSelectionSet(result, {
+              ...leftSelection,
+              selectionSet: leftOuterJoinSub,
+            })
+          }
+        }
+        found = true
+        break
+      }
+    }
+    if (found) {
+      continue
+    }
+
+    mergeFieldNodeInToSelectionSet(result, leftSelection)
+  }
+
+  return result
+}

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,8 @@
-import { lazyProperty } from './utils'
+import deepmerge from 'deepmerge'
+
+import { lazyProperty, dataMerge, arrayMerge } from './utils'
+
+jest.mock('deepmerge')
 
 describe('lazyProperty', () => {
   it('defines a property without executing the instantiator', () => {
@@ -20,5 +24,66 @@ describe('lazyProperty', () => {
     expect(target.property).toBe(result)
     expect(target.property).toBe(result)
     expect(instantiator).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('dataMerge', () => {
+  it('calls deepmerge with configuration', () => {
+    const result = Symbol('result')
+    ;(deepmerge as any as jest.Mock).mockReturnValue(result)
+
+    const source = Symbol('source')
+    const destination = Symbol('destination')
+
+    expect(dataMerge(destination, source)).toBe(result)
+
+    expect(deepmerge).toHaveBeenCalledTimes(1)
+    expect(deepmerge).toHaveBeenCalledWith(destination, source, {
+      arrayMerge,
+      clone: false,
+    })
+  })
+})
+
+describe('arrayMerge', () => {
+  beforeEach(() => {
+    ;(deepmerge as any as jest.Mock).mockReset()
+  })
+
+  it.each([
+    [undefined, undefined, undefined],
+    [undefined, null, null],
+    [undefined, {}, {}],
+    [null, undefined, null],
+    [null, null, null],
+    [null, {}, {}],
+    [{}, undefined, {}],
+    [{}, null, {}],
+  ])('handles array with %0 and %1 to produce %2', (inputA, inputB, output) => {
+    expect(arrayMerge([inputA], [inputB])).toEqual([output])
+  })
+
+  it('calls deepmerge if required', () => {
+    const options = Symbol('options')
+    const result = Symbol('result')
+
+    ;(deepmerge as any as jest.Mock).mockReturnValue(result)
+
+    expect(arrayMerge(
+      [
+        { left: true },
+      ],
+      [
+        { right: true },
+      ],
+      options as deepmerge.Options
+    )).toEqual([result])
+
+    expect(deepmerge).toHaveBeenCalledTimes(1)
+    expect(deepmerge).toHaveBeenCalledWith(
+      { left: true },
+      { right: true },
+      options
+    )
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import deepmerge from 'deepmerge'
+
 // Gets the union type of all keys of T
 type ValueOf<T> = T[keyof T]
 
@@ -22,3 +24,23 @@ export const lazyProperty = <
     },
   })
 }
+
+export const dataMerge = (destination: any, source: any) =>
+  deepmerge(destination, source, {
+    arrayMerge,
+    clone: false,
+  })
+
+export const arrayMerge = (destination: any[], source: any[], options?: deepmerge.Options) =>
+  Array.from({ length: Math.max(destination.length, source.length) }, (_, i) => {
+    if (destination[i] === undefined) {
+      return source[i]
+    }
+    if (source[i] === undefined) {
+      return destination[i]
+    }
+    if (!destination[i] || !source[i]) {
+      return destination[i] || source[i]
+    }
+    return deepmerge(destination[i], source[i], options)
+  })

--- a/test/integration/arraySiblings.test.ts
+++ b/test/integration/arraySiblings.test.ts
@@ -1,0 +1,33 @@
+import { buildSchema } from 'graphql/utilities'
+
+import GraphQLAutoRequester from '../../src/index'
+
+const schema = buildSchema(`
+  type X {
+    value: Int!
+  }
+
+  type Query {
+    getXs: [X!]!
+  }
+`)
+const fields = schema.getQueryType()!.getFields()
+fields.getXs.resolve = () => Array.from({ length: 100 }, (_, i) => ({ value: i }))
+
+describe('Array siblings', () => {
+  let requester: GraphQLAutoRequester
+  let query: any
+  beforeEach(() => {
+    requester = new GraphQLAutoRequester(schema)
+    jest.spyOn(requester, 'execute')
+    query = requester.query!
+  })
+
+  it('only queries once for the same field in siblings', async () => {
+    const array = await query.getXs
+    for (let i = 0; i < array.length; i++) {
+      expect(await array[i].value).toBe(i)
+    }
+    expect(requester.execute).toHaveBeenCalledTimes(2)
+  })
+})

--- a/test/integration/collatz.test.ts
+++ b/test/integration/collatz.test.ts
@@ -24,6 +24,10 @@ numberType.getFields().div.resolve = ({ value }, { input }) => ({ value: Math.fl
 numberType.getFields().mult.resolve = ({ value }, { input }) => ({ value: value * input })
 numberType.getFields().sub.resolve = ({ value }, { input }) => ({ value: value - input })
 
+// TODO: Performance is not great when querying extremely deep in the tree
+// See issue #6
+jest.setTimeout(10000)
+
 describe('The Collatz conjecture example', () => {
   const expectedFirstRequest = `\
 {

--- a/test/integration/index.test.ts
+++ b/test/integration/index.test.ts
@@ -341,8 +341,7 @@ describe('GraphQLAutoRequester', () => {
     }
     expect(list.filter((x: any) => x)).toHaveLength(5)
 
-    // TODO: This should only need 2 requests, with a data caching solution
-    expect(requester.execute).toHaveBeenCalledTimes(6)
+    expect(requester.execute).toHaveBeenCalledTimes(2)
   })
 
   it('resolves a scalar field on a nullable list of nullable unions correctly', async () => {
@@ -387,8 +386,7 @@ describe('GraphQLAutoRequester', () => {
       }
     }
 
-    // TODO: This should only need 3 requests, with a data caching solution
-    expect(requester.execute).toHaveBeenCalledTimes(6)
+    expect(requester.execute).toHaveBeenCalledTimes(2)
   })
 
   it('resolves fields in parallel', async () => {


### PR DESCRIPTION
Querying fields on siblings should now be more performant

Fixes #3 