### PR TITLE
Refactor fragment type map

### DIFF
--- a/src/fragmentTypemap.test.ts
+++ b/src/fragmentTypemap.test.ts
@@ -26,6 +26,10 @@ const schema = buildSchema(`
   }
 
   union Union = X
+
+  type Query {
+    field: Int
+  }
 `)
 
 describe('parseTypeMapFromGraphQLDocument', () => {
@@ -42,7 +46,7 @@ describe('parseTypeMapFromGraphQLDocument', () => {
       fragment fakeFragment on FakeType {
         field
       }
-    `)).toThrow('Unknown type FakeType appearing in preload fragments.')
+    `)).toThrow('Unknown type "FakeType".')
   })
 
   it('prevents a fragment on a scalar', () => {
@@ -50,15 +54,13 @@ describe('parseTypeMapFromGraphQLDocument', () => {
       fragment unionFragment on Scalar {
         field
       }
-    `)).toThrow('You cannot add a preload fragment to the non-composite type Scalar.')
+    `)).toThrow('Fragment "unionFragment" cannot condition on non composite type "Scalar".')
   })
 
   it('prevents a fragment on a union', () => {
     expect(() => parseTypeMapFromGraphQLDocument(schema, `
       fragment unionFragment on Union {
-        ... on Inter {
-          interfaceField
-        }
+        field
       }
     `)).toThrow('You cannot add a preload fragment to the Union type Union.')
   })
@@ -76,9 +78,9 @@ describe('parseTypeMapFromGraphQLDocument', () => {
   it('prevents a fragment with an aliased field', () => {
     expect(() => parseTypeMapFromGraphQLDocument(schema, `
       fragment xFragment on X {
-        alias: type
+        alias: test
       }
-    `)).toThrow('X.type must not have an alias.')
+    `)).toThrow('X.test must not have an alias.')
   })
 
   it('prevents a fragment with an implemented field', () => {

--- a/src/fragmentTypemap.ts
+++ b/src/fragmentTypemap.ts
@@ -1,4 +1,4 @@
-import { DocumentNode, parse, Kind, SelectionSetNode, GraphQLSchema, isObjectType, isUnionType, isAbstractType, doTypesOverlap, isCompositeType, GraphQLCompositeType, GraphQLObjectType, isInterfaceType, visit, TypeInfo, FieldNode, visitWithTypeInfo, FragmentDefinitionNode } from 'graphql'
+import { DocumentNode, parse, Kind, SelectionSetNode, GraphQLSchema, isObjectType, isUnionType, isAbstractType, doTypesOverlap, isCompositeType, GraphQLCompositeType, GraphQLObjectType, isInterfaceType, visit, TypeInfo, FieldNode, visitWithTypeInfo, FragmentDefinitionNode, NoUnusedFragmentsRule, validate, specifiedRules, ValidationContext, GraphQLError, OverlappingFieldsCanBeMergedRule } from 'graphql'
 import { mergeSelectionSetInToSelectionSet, mergeFieldNodeInToSelectionSet } from './selectionSet'
 import GraphQLAutoRequester from '.'
 import { getFieldAlias, getArgumentsFromNodes, getInputArgumentNodes } from './utils'
@@ -6,6 +6,50 @@ import { getFieldAlias, getArgumentsFromNodes, getInputArgumentNodes } from './u
 export type GraphQLFragmentTypeMap = {
   [typename: string]: SelectionSetNode
 }
+
+const noUnionFragmentDefinitionRule = (context: ValidationContext) => ({
+  FragmentDefinition (node: FragmentDefinitionNode) {
+    const type = context.getType()
+    if (isUnionType(type)) {
+      context.reportError(new GraphQLError(`You cannot add a preload fragment to the Union type ${type.name}.`, node))
+    }
+  },
+})
+
+const noFieldAliasesRule = (context: ValidationContext) => ({
+  Field (node: FieldNode) {
+    if (node.alias) {
+      context.reportError(new GraphQLError(`${context.getParentType()!.name}.${node.name.value} must not have an alias.`, node))
+    }
+  },
+})
+
+const noFieldsFromInterfaces = (context: ValidationContext) => ({
+  Field (node: FieldNode) {
+    const type = context.getParentType()
+    if (isObjectType(type)) {
+      for (const interfaceType of type.getInterfaces()) {
+        if (node.name.value in interfaceType.getFields()) {
+          throw new Error(`${type.name}.${node.name.value} must not appear in this preload as it is from one or more interfaces.`)
+        }
+      }
+    }
+  },
+})
+
+const noInlineFragment = (context: ValidationContext) => ({
+  InlineFragment () {
+    const type: GraphQLCompositeType = context.getParentType()!
+    throw new Error(`You cannot include an inline spread in a preload. Found in type ${type.name}.`)
+  },
+})
+
+const noFragmentSpreads = (context: ValidationContext) => ({
+  FragmentSpread () {
+    const type: GraphQLCompositeType = context.getParentType()!
+    throw new Error(`You cannot include a fragment spread in a preload. Found in type ${type.name}.`)
+  },
+})
 
 export const parseTypeMapFromGraphQLDocument = (schema: GraphQLSchema, document: string | DocumentNode | undefined): GraphQLFragmentTypeMap => {
   if (!document) {
@@ -16,76 +60,73 @@ export const parseTypeMapFromGraphQLDocument = (schema: GraphQLSchema, document:
     document = parse(document)
   }
 
-  const map: GraphQLFragmentTypeMap = {}
-
-  for (let fragment of document.definitions) {
-    if (fragment.kind !== Kind.FRAGMENT_DEFINITION) {
-      throw new Error('The provided GraphQL document contained items that weren\'t fragments.')
-    }
-    const typeName = fragment.typeCondition.name.value
-    const type = schema.getType(typeName)
-    if (!type) {
-      throw new Error(`Unknown type ${typeName} appearing in preload fragments.`)
-    }
-    if (!isCompositeType(type)) {
-      throw new Error(`You cannot add a preload fragment to the non-composite type ${typeName}.`)
-    }
-    if (isUnionType(type)) {
-      throw new Error(`You cannot add a preload fragment to the Union type ${typeName}.`)
-    }
-    if (!map[typeName]) {
-      map[typeName] = {
-        kind: Kind.SELECTION_SET,
-        selections: [],
-      }
-    }
-
-    const typeInfo = new TypeInfo(schema)
-    fragment = visit(fragment, visitWithTypeInfo(typeInfo, {
-      Field (node: FieldNode): FieldNode | undefined {
-        const type: GraphQLCompositeType = typeInfo.getParentType()! as GraphQLCompositeType
-        if (isUnionType(type)) {
-          throw new Error('Unexpected field on a union type.')
-        }
-
-        if (isObjectType(type)) {
-          for (const interfaceType of type.getInterfaces()) {
-            if (node.name.value in interfaceType.getFields()) {
-              throw new Error(`${typeName}.${node.name.value} must not appear in this preload as it is from one or more interfaces.`)
-            }
-          }
-        }
-
-        if (node.alias) {
-          throw new Error(`${type.name}.${node.name.value} must not have an alias.`)
-        }
-
-        const field = type.getFields()[node.name.value]!
-        if (field.args.length) {
-          const inputs = getArgumentsFromNodes(field, node.arguments)
-          const nodeArguments = getInputArgumentNodes(field, inputs)
-          const alias = getFieldAlias(field, node.arguments)
-          return {
-            ...node,
-            alias: {
-              kind: Kind.NAME,
-              value: alias,
-            },
-            arguments: nodeArguments,
-          }
-        }
-      },
-      InlineFragment () {
-        const type: GraphQLCompositeType = typeInfo.getParentType()! as GraphQLCompositeType
-        throw new Error(`You cannot include an inline spread in a preload. Found in type ${type.name}.`)
-      },
-      FragmentSpread () {
-        const type: GraphQLCompositeType = typeInfo.getParentType()! as GraphQLCompositeType
-        throw new Error(`You cannot include a fragment spread in a preload. Found in type ${type.name}.`)
-      },
-    })) as FragmentDefinitionNode
-    mergeSelectionSetInToSelectionSet(map[typeName], fragment.selectionSet)
+  if (document.definitions.some(definition => definition.kind !== Kind.FRAGMENT_DEFINITION)) {
+    throw new Error('The provided GraphQL document contained items that weren\'t fragments.')
   }
+
+  const errors = validate(schema, document, [
+    ...specifiedRules
+      .filter(rule => rule !== OverlappingFieldsCanBeMergedRule)
+      .filter(rule => rule !== NoUnusedFragmentsRule),
+
+    noUnionFragmentDefinitionRule,
+    noFieldAliasesRule,
+    noFieldsFromInterfaces,
+    noInlineFragment,
+    noFragmentSpreads,
+  ])
+
+  if (errors && errors[0]) {
+    throw errors[0]
+  }
+
+  const typeInfo = new TypeInfo(schema)
+  const aliasedDocument = visit(document, visitWithTypeInfo(typeInfo, {
+    Field (node: FieldNode): FieldNode | undefined {
+      const type: GraphQLCompositeType = typeInfo.getParentType()! as GraphQLCompositeType
+      if (isUnionType(type)) {
+        throw new Error('Unexpected field on a union type.')
+      }
+
+      const field = type.getFields()[node.name.value]!
+      if (field.args.length) {
+        const inputs = getArgumentsFromNodes(field, node.arguments)
+        const nodeArguments = getInputArgumentNodes(field, inputs)
+        const alias = getFieldAlias(field, node.arguments)
+        return {
+          ...node,
+          alias: {
+            kind: Kind.NAME,
+            value: alias,
+          },
+          arguments: nodeArguments,
+        }
+      }
+    },
+  }))
+
+  const errors2 = validate(schema, aliasedDocument,
+    specifiedRules
+      .filter(rule => rule !== NoUnusedFragmentsRule)
+  )
+  if (errors2 && errors2[0]) {
+    throw errors2[0]
+  }
+
+  const map: GraphQLFragmentTypeMap = {}
+  visit(aliasedDocument, {
+    FragmentDefinition (node: FragmentDefinitionNode) {
+      const typeName = node.typeCondition.name.value
+      if (!map[typeName]) {
+        map[typeName] = {
+          kind: Kind.SELECTION_SET,
+          selections: [],
+        }
+      }
+
+      mergeSelectionSetInToSelectionSet(map[typeName], node.selectionSet)
+    },
+  })
 
   return map
 }

--- a/test/integration/fragments/fragmentSpreads.test.ts
+++ b/test/integration/fragments/fragmentSpreads.test.ts
@@ -1,0 +1,75 @@
+import { buildSchema, GraphQLObjectType } from 'graphql'
+
+import GraphQLAutoRequester from '../../../src'
+
+const schema = buildSchema(`
+  type Y {
+    field: Int!
+    field2: Int!
+  }
+  type X {
+    child: Y!
+    field: Int!
+  }
+  type Query {
+    testExample: X
+    testExample2: Y
+  }
+`)
+const fields = schema.getQueryType()!.getFields()
+fields.testExample.resolve = () => ({
+  field: 10,
+  child: {
+    field: 20,
+    field2: 30,
+  },
+})
+fields.testExample2.resolve = () => ({
+  field: 40,
+  field2: 50,
+})
+
+describe('for fragment spreads in preloads', () => {
+  let requester: GraphQLAutoRequester
+  let query: any
+  beforeEach(() => {
+    requester = new GraphQLAutoRequester(schema, {
+      fragments: `
+        fragment y on Y {
+          field
+        }
+        fragment x on X {
+          child {
+            ...y
+          }
+        }
+      `
+    })
+    jest.spyOn(requester, 'execute')
+    query = requester.query!
+  })
+
+  it ('requests the same field multiple times correctly', async () => {
+    const x = await query.testExample
+    expect(requester.execute).toHaveBeenCalledTimes(1)
+
+    const child = await x.child
+    expect(requester.execute).toHaveBeenCalledTimes(1)
+    await expect(child.field).resolves.toEqual(20)
+
+    await expect(x.field).resolves.toEqual(10)
+    expect(requester.execute).toHaveBeenCalledTimes(2)
+
+    await expect(child.field2).resolves.toEqual(30)
+    expect(requester.execute).toHaveBeenCalledTimes(3)
+
+    const baseY = await query.testExample2
+    expect(requester.execute).toHaveBeenCalledTimes(4)
+
+    await expect(baseY.field).resolves.toEqual(40)
+    expect(requester.execute).toHaveBeenCalledTimes(4)
+
+    await expect(baseY.field2).resolves.toEqual(50)
+    expect(requester.execute).toHaveBeenCalledTimes(5)
+  })
+})


### PR DESCRIPTION
- Validation now uses graphql-js validation
- Fragment spreads are supported.