### PR TITLE
Bugfix for Proxied Schemas

### DIFF
--- a/src/fragmentTypemap.test.ts
+++ b/src/fragmentTypemap.test.ts
@@ -387,6 +387,13 @@ describe('canonicalizeRequestedFields', () => {
           kind: Kind.FIELD,
           name: {
             kind: Kind.NAME,
+            value: '__typename',
+          },
+          selectionSet: undefined,
+        }, {
+          kind: Kind.FIELD,
+          name: {
+            kind: Kind.NAME,
             value: 'interfaceField',
           },
           selectionSet: undefined,
@@ -437,6 +444,13 @@ describe('canonicalizeRequestedFields', () => {
       .toEqual({
         kind: Kind.SELECTION_SET,
         selections: [{
+          kind: Kind.FIELD,
+          name: {
+            kind: Kind.NAME,
+            value: '__typename',
+          },
+          selectionSet: undefined,
+        }, {
           kind: Kind.INLINE_FRAGMENT,
           typeCondition: {
             kind: Kind.NAMED_TYPE,

--- a/src/fragmentTypemap.ts
+++ b/src/fragmentTypemap.ts
@@ -224,7 +224,13 @@ export const canonicalizeRequestedFields = (rootType: GraphQLCompositeType, conc
   }
   const rootSelections = {
     kind: Kind.SELECTION_SET,
-    selections: [],
+    selections: [{
+      kind: Kind.FIELD,
+      name: {
+        kind: Kind.NAME,
+        value: '__typename',
+      },
+    }],
   }
   const fragmentSelections = {
     kind: Kind.SELECTION_SET,

--- a/test/integration/remoteSchema.test.ts
+++ b/test/integration/remoteSchema.test.ts
@@ -4,7 +4,7 @@ import { buildSchema } from 'graphql/utilities'
 import GraphQLAutoRequester from '../../src/index'
 
 describe('For proxied schemas', () => {
-  it('resolves an union multiple times', async () => {
+  it('requests __typename for a union multiple times', async () => {
     const schemaDocument = `
       type A {
         value: Int
@@ -48,7 +48,7 @@ describe('For proxied schemas', () => {
     expect(requester.execute).toHaveBeenCalledTimes(2)
   })
 
-  it('resolves an interface multiple times', async () => {
+  it('requests __typename for an interface multiple times', async () => {
     const schemaDocument = `
       interface TestInterface {
         value: Int

--- a/test/integration/remoteSchema.test.ts
+++ b/test/integration/remoteSchema.test.ts
@@ -1,0 +1,96 @@
+import { execute, Kind } from 'graphql'
+import { buildSchema } from 'graphql/utilities'
+
+import GraphQLAutoRequester from '../../src/index'
+
+describe('For proxied schemas', () => {
+  it('resolves an union multiple times', async () => {
+    const schemaDocument = `
+      type A {
+        value: Int
+      }
+
+      union TestUnion = A
+
+      type Query {
+        testValue: TestUnion
+      }
+    `
+    const remoteSchema = buildSchema(schemaDocument)
+    const remoteFields = remoteSchema.getQueryType()!.getFields()
+    remoteFields.testValue.resolve = () => ({
+      __typename: 'A',
+      value: 10,
+    })
+
+    const localSchema = buildSchema(schemaDocument)
+    const localFields = localSchema.getQueryType()!.getFields()
+    localFields.testValue.resolve = async (parent, args, context, info) => {
+      const result = await execute({
+        schema: remoteSchema,
+        document: {
+          kind: Kind.DOCUMENT,
+          definitions: [
+            info.operation,
+          ],
+        },
+      })
+      return result.data[info.fieldName]
+    }
+
+    const requester = new GraphQLAutoRequester(localSchema)
+    jest.spyOn(requester, 'execute')
+    const newQuery: any = requester.query
+
+    const union = await newQuery!.testValue
+    await expect(union.value).resolves.toBe(10)
+
+    expect(requester.execute).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves an interface multiple times', async () => {
+    const schemaDocument = `
+      interface TestInterface {
+        value: Int
+      }
+
+      type A implements TestInterface {
+        value: Int
+      }
+
+      type Query {
+        testValue: TestInterface
+      }
+    `
+    const remoteSchema = buildSchema(schemaDocument)
+    const remoteFields = remoteSchema.getQueryType()!.getFields()
+    remoteFields.testValue.resolve = () => ({
+      __typename: 'A',
+      value: 10,
+    })
+
+    const localSchema = buildSchema(schemaDocument)
+    const localFields = localSchema.getQueryType()!.getFields()
+    localFields.testValue.resolve = async (parent, args, context, info) => {
+      const result = await execute({
+        schema: remoteSchema,
+        document: {
+          kind: Kind.DOCUMENT,
+          definitions: [
+            info.operation,
+          ],
+        },
+      })
+      return result.data[info.fieldName]
+    }
+
+    const requester = new GraphQLAutoRequester(localSchema)
+    jest.spyOn(requester, 'execute')
+    const newQuery: any = requester.query
+
+    const union = await newQuery!.testValue
+    await expect(union.value).resolves.toBe(10)
+
+    expect(requester.execute).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
- Always fetch __typename for Abstract types to ensure that any GraphQL proxies can know the type.
- Fixes #23